### PR TITLE
Mention CSP in output section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Checklist of the most important security countermeasures when designing,testing,
 ## OUTPUT
 - [ ] Send `X-Content-Type-Options: nosniff` header.
 - [ ] Send `X-Frame-Options: deny` header.
+- [ ] Send `Content-Security-Policy: default-src 'none'` header.
 - [ ] Force `content-type` for your response , if you return `application/json` then your response `content-type` is `application/json`.
 - [ ] Don't return sensetive data like `credentials` , `Passwords`, `security tokens`.
 - [ ] Return proper status code according to operation you done. (e.g. `200 OK` , `400 Bad Request` , `401 Unauthorized`, `405 Method Not Allowed` ... etc).


### PR DESCRIPTION
This disables pretty much everything on the api since it's not ment to be consumed by browsers directly.