### PR TITLE
Fix polish translation about decoding JWT payload

### DIFF
--- a/README-pl.md
+++ b/README-pl.md
@@ -16,7 +16,7 @@ Lista kontrolna najważniejszych metod zabezpieczenia podczas projektowania, tes
 - [ ] Użyj losowego, skomplikowanego klucza (`JWT Secret`) aby uczynić token bezpieczniejszym przeciw atakom typu `brute force`.
 - [ ] Algorytmy trzymaj w backendzie, nie upubliczniaj algorytmów.
 - [ ] Ustaw wygaszanie tokenów (`TTL`, `RTTL`) najkrótsze jak to możliwe.
-- [ ] Nie przechowuj wrażliwych danych w `JWT payload`, mogą był łatwo dekodowane przy pomocy [easily](https://jwt.io/#debugger-io).
+- [ ] Nie przechowuj wrażliwych danych w payloadzie `JWT`, mogą być one [łatwo zdekodowane](https://jwt.io/#debugger-io).
 
 ### OAuth
 - [ ] Zawsze waliduj `redirect_uri` po stronie serwera aby zezwolić tylko URL-om z dozwolonej listy (`whitelist`).


### PR DESCRIPTION
> mogą był łatwo dekodowane przy pomocy easily

It looks a bit like a google translate...

Let me explain if there is no native-polish reviewer:
* `easily` is an english word, assuming there was an automatic translation - this word hasn't been translated as it was a link (it is `łatwo` in polish)
* `był` should be `być` or `zostać` (`był` is a past form of `be` so it is more like `was` or `were`)
* `dekodowane` -> `zdekodowane` - proper form

I used `payloadzie` out of the code syntax as some ppl sometimes mix foreign words into polish and change them a bit accorrding to a proper [polish] grammatic forms.