### PR TITLE
Improve billion laughts attack

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -41,8 +41,8 @@ Lista de las contramedidas de seguridad más importantes en cuanto al diseño, t
 - [ ] Valida que todos los endpoints estén protegidos con autenticación para evitar romper el proceso de autenticación.
 - [ ] Debes evitar los recursos bajo un ID de usuario. Usa `/me/orders` en lugar de `/user/654321/orders`.
 - [ ] No uses IDs auto incrementales. Usa `UUID` en su lugar.
-- [ ] Si estas procesando archivos XML, asegúrate de deshabilitar el procesamiento de entidades para evitar ataques `XXE` (XML external entity attack).
-- [ ] Si estas procesando archivos XML, asegúrate de deshabilitar la expansión de entidades, para evitar un ataque `Billion Laughs/XML bomb` via expansión exponencial de entidades.
+- [ ] Si estas procesando XML, asegúrate de deshabilitar el procesamiento de entidades para evitar ataques `XXE` (XML external entity attack).
+- [ ] Si estas procesando XML, YAML o algún otro lenguaje con soporte para anchors y referencias, asegúrate de deshabilitar la expansión de entidades, para evitar un ataque `Billion Laughs/XML bomb` via expansión exponencial de entidades.
 - [ ] Utiliza CDN para subidas de ficheros.
 - [ ] Si lidias con grandes cantidades de información, utiliza Workers y Colas para procesar tanto cómo sea posible en segundo plano, y devuelve una respuesta rápido para evitar un bloqueo HTTP.
 - [ ] No olvides deshabilitar el modo Debug.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[繁中版](./README-tw.md) | [简中版](./README-zh.md) | [Português (Brasil)](./README-pt_BR.md) | [Français](./README-fr.md) | [한국어](./README-ko.md) | [Nederlands](./README-nl.md) | [Indonesia](./README-id.md) | [ไทย](./README-th.md) | [Русский](./README-ru.md) | [Українська](./README-uk.md) | [Español](./README-es.md) | [Italiano](./README-it.md) | [日本語](./README-ja.md) | [Deutsch](./README-de.md) | [Türkçe](./README-tr.md) | [Tiếng Việt](./README-vi.md) | [Монгол](./README-mn.md) | [हिंदी](./README-hi.md) | [العربية](./README-ar.md) | [Polski](./README-pl.md) | [Македонски](./README-mk.md) | [ລາວ](./README-lo.md) | [Ελληνικά](./README-el.md) | [فارسی](./README-fa.md) | [മലയാളം](./README-ml.md) 
+[繁中版](./README-tw.md) | [简中版](./README-zh.md) | [Português (Brasil)](./README-pt_BR.md) | [Français](./README-fr.md) | [한국어](./README-ko.md) | [Nederlands](./README-nl.md) | [Indonesia](./README-id.md) | [ไทย](./README-th.md) | [Русский](./README-ru.md) | [Українська](./README-uk.md) | [Español](./README-es.md) | [Italiano](./README-it.md) | [日本語](./README-ja.md) | [Deutsch](./README-de.md) | [Türkçe](./README-tr.md) | [Tiếng Việt](./README-vi.md) | [Монгол](./README-mn.md) | [हिंदी](./README-hi.md) | [العربية](./README-ar.md) | [Polski](./README-pl.md) | [Македонски](./README-mk.md) | [ລາວ](./README-lo.md) | [Ελληνικά](./README-el.md) | [فارسی](./README-fa.md) | [മലയാളം](./README-ml.md)
 
 # API Security Checklist
 Checklist of the most important security countermeasures when designing, testing, and releasing your API.
@@ -42,8 +42,8 @@ Checklist of the most important security countermeasures when designing, testing
 - [ ] Check if all the endpoints are protected behind authentication to avoid broken authentication process.
 - [ ] User own resource ID should be avoided. Use `/me/orders` instead of `/user/654321/orders`.
 - [ ] Don't auto-increment IDs. Use `UUID` instead.
-- [ ] If you are parsing XML files, make sure entity parsing is not enabled to avoid `XXE` (XML external entity attack).
-- [ ] If you are parsing XML files, make sure entity expansion is not enabled to avoid `Billion Laughs/XML bomb` via exponential entity expansion attack.
+- [ ] If you are parsing XML data, make sure entity parsing is not enabled to avoid `XXE` (XML external entity attack).
+- [ ] If you are parsing XML, YAML or any other language with anchors and refs, make sure entity expansion is not enabled to avoid `Billion Laughs/XML bomb` via exponential entity expansion attack.
 - [ ] Use a CDN for file uploads.
 - [ ] If you are dealing with huge amount of data, use Workers and Queues to process as much as possible in background and return response fast to avoid HTTP Blocking.
 - [ ] Do not forget to turn the DEBUG mode OFF.


### PR DESCRIPTION
billion laughts attack can be done for in-memory data, not only files, and might happen on any language containing anchors and references, like YAML.

Added spanish translation as well.