### PR TITLE
Add http headers size limit problem

### DIFF
--- a/README-es.md
+++ b/README-es.md
@@ -17,6 +17,7 @@ Lista de las contramedidas de seguridad más importantes en cuanto al diseño, t
 - [ ] No extraigas el algoritmo del contenido. Fuerza el algoritmo en el backend (`HS256` o `RS256`).
 - [ ] Haz que la expiración del token (`TTL`, `RTTL`) sea tan corta como sea posible.
 - [ ] No almacenes información sensible en el contenido del JWT, puede ser descodificado [fácilmente](https://jwt.io/#debugger-io).
+- [ ] Evita almacenar datos muy grandes o crecientes. JWT se transmite en las headers y éstas tienen un tamaño máximo.
 
 ### OAuth
 - [ ] Siempre valida `redirect_uri` en el lado del servidor para permitir sólo ciertas URLs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[繁中版](./README-tw.md) | [简中版](./README-zh.md) | [Português (Brasil)](./README-pt_BR.md) | [Français](./README-fr.md) | [한국어](./README-ko.md) | [Nederlands](./README-nl.md) | [Indonesia](./README-id.md) | [ไทย](./README-th.md) | [Русский](./README-ru.md) | [Українська](./README-uk.md) | [Español](./README-es.md) | [Italiano](./README-it.md) | [日本語](./README-ja.md) | [Deutsch](./README-de.md) | [Türkçe](./README-tr.md) | [Tiếng Việt](./README-vi.md) | [Монгол](./README-mn.md) | [हिंदी](./README-hi.md) | [العربية](./README-ar.md) | [Polski](./README-pl.md) | [Македонски](./README-mk.md) | [ລາວ](./README-lo.md) | [Ελληνικά](./README-el.md) | [فارسی](./README-fa.md) | [മലയാളം](./README-ml.md) 
+[繁中版](./README-tw.md) | [简中版](./README-zh.md) | [Português (Brasil)](./README-pt_BR.md) | [Français](./README-fr.md) | [한국어](./README-ko.md) | [Nederlands](./README-nl.md) | [Indonesia](./README-id.md) | [ไทย](./README-th.md) | [Русский](./README-ru.md) | [Українська](./README-uk.md) | [Español](./README-es.md) | [Italiano](./README-it.md) | [日本語](./README-ja.md) | [Deutsch](./README-de.md) | [Türkçe](./README-tr.md) | [Tiếng Việt](./README-vi.md) | [Монгол](./README-mn.md) | [हिंदी](./README-hi.md) | [العربية](./README-ar.md) | [Polski](./README-pl.md) | [Македонски](./README-mk.md) | [ລາວ](./README-lo.md) | [Ελληνικά](./README-el.md) | [فارسی](./README-fa.md) | [മലയാളം](./README-ml.md)
 
 # API Security Checklist
 Checklist of the most important security countermeasures when designing, testing, and releasing your API.
@@ -17,6 +17,7 @@ Checklist of the most important security countermeasures when designing, testing
 - [ ] Don't extract the algorithm from the header. Force the algorithm in the backend (`HS256` or `RS256`).
 - [ ] Make token expiration (`TTL`, `RTTL`) as short as possible.
 - [ ] Don't store sensitive data in the JWT payload, it can be decoded [easily](https://jwt.io/#debugger-io).
+- [ ] Avoid storing too much or growing up data. JWT is usually shared in headers and they have a size limit.
 
 ### OAuth
 - [ ] Always validate `redirect_uri` server-side to allow only whitelisted URLs.


### PR DESCRIPTION
WT adds a header and a signature (usually the same one, size constant for both), and encodes data in base64, what requires around 4/3 the original data size.

Including data that grows up, such as a list of role descriptions that can be added to the user, it is easy to create a big JWT.

Problems:

    This big JWT is going to be sent on every communication, generating larger messages and consuming more network resources.
    Every web server has a header size limit that is between 4k and 48k. Any header beyond that will be rejected, generating a hard to debug selective DoS problem.

Added spanish translation as well.