### PR TITLE
You don't need JWT

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,6 @@ Checklist of the most important security countermeasures when designing, testing
 - [ ] Use `Max Retry` and jail features in Login.
 - [ ] Use encryption on all sensitive data.
 
-### JWT (JSON Web Token)
-
-- [ ] Use a random complicated key (`JWT Secret`) to make brute forcing the token very hard.
-- [ ] Don't extract the algorithm from the header. Force the algorithm in the backend (`HS256` or `RS256`).
-- [ ] Make token expiration (`TTL`, `RTTL`) as short as possible.
-- [ ] Don't store sensitive data in the JWT payload, it can be decoded [easily](https://jwt.io/#debugger-io).
-- [ ] Avoid storing too much data. JWT is usually shared in headers and they have a size limit.
-
 ## Access
 
 - [ ] Limit requests (Throttling) to avoid DDoS / brute-force attacks.
@@ -93,6 +85,7 @@ Checklist of the most important security countermeasures when designing, testing
 ## See also:
 
 - [yosriady/api-development-tools](https://github.com/yosriady/api-development-tools) - A collection of useful resources for building RESTful HTTP+JSON APIs.
+- You don't need JWT, in general just use bearer tokens. If you need asymetric encryption or tamper prevention [here are some alternative suggestions](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Checklist of the most important security countermeasures when designing, testing
 ## See also:
 
 - [yosriady/api-development-tools](https://github.com/yosriady/api-development-tools) - A collection of useful resources for building RESTful HTTP+JSON APIs.
-- You don't need JWT, in general just use bearer tokens. If you need asymetric encryption or tamper prevention [here are some alternative suggestions](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/)
+- You don't need JWT, just use a randomly generated API key. If you need asymetric encryption or tamper prevention [here are some alternatives to JWT](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Checklist of the most important security countermeasures when designing, testing
 
 ## Authentication
 
-- [ ] Don't use `Basic Auth`. Use standard authentication instead (e.g., [JWT](https://jwt.io/)).
+- [ ] Don't use `Basic Auth`. Use standard authentication instead.
 - [ ] Don't reinvent the wheel in `Authentication`, `token generation`, `password storage`. Use the standards.
 - [ ] Use `Max Retry` and jail features in Login.
 - [ ] Use encryption on all sensitive data.
@@ -85,7 +85,7 @@ Checklist of the most important security countermeasures when designing, testing
 ## See also:
 
 - [yosriady/api-development-tools](https://github.com/yosriady/api-development-tools) - A collection of useful resources for building RESTful HTTP+JSON APIs.
-- You don't need JWT, just use a randomly generated API key. If you need asymetric encryption or tamper prevention [here are some alternatives to JWT](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/)
+- You don't need JWT, just use a randomly generated API key. If you need asymmetric encryption or tamper prevention [here are some alternatives to JWT](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/)
 
 ---
 


### PR DESCRIPTION
You don't need JWT if you are just authenticating users - just use a bearer token with TLS. Put it in the authorization header or query string.

There are a bunch of people asking in the original issue (#6) "but what should I use instead of JWT?"

The answer is - just a token. If you're using HTTPS, it's secure.

@rdegges wrote [a comment](https://github.com/shieldfy/API-Security-Checklist/issues/6#issuecomment-371038523) that has some additional information but says the important part clearly:

> In pretty much every single situation imaginable JWTs are worse than just using a randomly generated API key of some sort (or session ID if we're talking about web apps). There is no benefit to using them, only downsides.

I included [a link](https://kevin.burke.dev/kevin/things-to-use-instead-of-jwt/) from [another of the comments](https://github.com/shieldfy/API-Security-Checklist/issues/6#issuecomment-316332544) from the original issue with some additional discussion of alternatives. 